### PR TITLE
I would suggest using individual packages in order to avoid dll mismatch

### DIFF
--- a/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
+++ b/Source/Xamarin/Prism.Unity.Forms/Prism.Unity.Forms.csproj
@@ -22,7 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity" Version="5.0.1" />
+    <PackageReference Include="Unity.Abstractions" Version="2.0.2" />
+    <PackageReference Include="Unity.Container" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I've split Unity into Abstractions and Container so you could link to Abstractions and switch Container implementations without a need to recompile. Will take a while before it is stable enough but should get there one day.

We are still working out kinks with composite package so it might not work as expected. 
 